### PR TITLE
Fix My Services button opening in new window

### DIFF
--- a/_includes/section-hero-image.html
+++ b/_includes/section-hero-image.html
@@ -34,7 +34,7 @@
             </div>
           </div>
           <div class="bts">
-            <a target="_blank" href="{{ content.button1.link }}" class="btn">
+            <a href="{{ content.button1.link }}" class="btn">
               <span>{{ content.button1.label }}</span>
             </a>
             <a href="{{ content.button2.link }}" class="btn-lnk">{{ content.button2.label }}</a>


### PR DESCRIPTION
Removed target="_blank" from the hero section's services button. It links to an anchor on the same page (#services-section) so it should scroll in place, not open a new tab.

https://claude.ai/code/session_019J4dLWDrNwHZ3VXbVncoar